### PR TITLE
pyobjc-core 9.0

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,3 +1,3 @@
 MACOSX_SDK_VERSION:        # [osx]
   - "11.3"                 # [osx and arm64]
-  - "10.15"                # [osx and x86_64]
+  - "11.0"                # [osx and x86_64]

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,3 +1,5 @@
 MACOSX_SDK_VERSION:        # [osx]
   - "11.3"                 # [osx and arm64]
-  - "11.0"                # [osx and x86_64]
+  - "10.15"                # [osx and x86_64]
+CONDA_BUILD_SYSROOT:       # [osx and x86_64]
+  - /opt/MacOSX10.15.sdk   # [osx and x86_64]

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,5 +1,5 @@
 MACOSX_SDK_VERSION:        # [osx]
   - "11.3"                 # [osx and arm64]
-  - "10.15"                # [osx and x86_64]
+  - 10.14                  # [osx and x86_64]
 CONDA_BUILD_SYSROOT:       # [osx and x86_64]
-  - /opt/MacOSX10.15.sdk   # [osx and x86_64]
+  - /opt/MacOSX10.14.sdk   # [osx and x86_64]

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,5 +1,7 @@
-MACOSX_SDK_VERSION:        # [osx]
-  - "11.3"                 # [osx and arm64]
-  - 10.14                  # [osx and x86_64]
+MACOSX_SDK_VERSION:       # [osx]
+  - "11.3"                  # [osx and arm64]
+  # SDK >=10.14 is needed on osx64 to prevent using the flag -Wno-unused-parameter, 
+  # see https://github.com/ronaldoussoren/pyobjc/blob/595adfb6a08b41da8d565bb28aa508b22c946e46/pyobjc-core/setup.py#L607
+  - "10.14"                  # [osx and x86_64]
 CONDA_BUILD_SYSROOT:       # [osx and x86_64]
   - /opt/MacOSX10.14.sdk   # [osx and x86_64]

--- a/recipe/fix_for_conda_build.diff
+++ b/recipe/fix_for_conda_build.diff
@@ -1,12 +1,13 @@
 diff --git a/pyobjc-core/setup.py b/pyobjc-core/setup.py
-index 0ed4c1bc3..21e1ee131 100644
+index e5d016531..5119bebf2 100644
 --- a/pyobjc-core/setup.py
 +++ b/pyobjc-core/setup.py
-@@ -87,7 +87,6 @@ CFLAGS = [
+@@ -87,7 +87,7 @@ CFLAGS = [
      # "-fsanitize=address", "-fsanitize=undefined", "-fno-sanitize=vptr",
      # "--analyze",
      "-Werror",
 -    "-I/usr/include/ffi",
++    "-Wno-unreachable-code",
      "-fvisibility=hidden",
-     # -O0", "-g"
-     "-O3",
+     # "-O0",
+     "-g",

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: {{ sha256 }}
   patches:
-  # Needs to prevent an error "code will never be executed" 
+  # Required to prevent an error "code will never be executed" 
   # in Modules/objc/class-builder.m:1999:17
     - fix_for_conda_build.diff
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,8 +10,10 @@ source:
   fn: {{ name }}-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: {{ sha256 }}
-  #patches:
-  #  - fix_for_conda_build.diff
+  patches:
+  # Needs to prevent an error "code will never be executed" 
+  # in Modules/objc/class-builder.m:1999:17
+    - fix_for_conda_build.diff
 
 build:
   number: 0
@@ -27,7 +29,7 @@ requirements:
   build:
     - {{ compiler('c') }}
     - libffi
-    #- patch
+    - patch
   host:
     - python
     - pip

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,8 +10,8 @@ source:
   fn: {{ name }}-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: {{ sha256 }}
-  patches:
-    - fix_for_conda_build.diff
+  #patches:
+  #  - fix_for_conda_build.diff
 
 build:
   number: 0
@@ -27,7 +27,7 @@ requirements:
   build:
     - {{ compiler('c') }}
     - libffi
-    - patch
+    #- patch
   host:
     - python
     - pip

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "pyobjc-core" %}
-{% set version = "8.5" %}
-{% set sha256 = "704c275439856c0d1287469f0d589a7d808d48b754a93d9ce5415d4eaf06d576" %}
+{% set version = "9.0" %}
+{% set sha256 = "3e7010c648eb94b16dd37a55f7719ed3bef6559edf4cf8fd741f46869dc223b1" %}
 
 package:
   name: {{ name }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,7 +20,7 @@ build:
   skip: true  # [not osx or py<37 or (arm64 and py<38)]
   script: 
     # force pyobjc to use conda-forge's chosen SDK
-    - export CFLAGS="${CFLAGS} -isysroot ${SDKROOT:-$CONDA_BUILD_SYSROOT}"
+    #- export CFLAGS="${CFLAGS} -isysroot ${SDKROOT:-$CONDA_BUILD_SYSROOT}"
     # force ignoring invalid compiler flag (-Wl,-export-dynamic)
     - export CFLAGS="${CFLAGS} -Wno-unused-command-line-argument"  # [py==37 or py==38]
     - {{ PYTHON }} -m pip install . --no-deps -vv

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,12 +15,12 @@ source:
 
 build:
   number: 0
-  skip: true  # [not osx or py<36 or (arm64 and py < 38)]
+  skip: true  # [not osx or py<37 or (arm64 and py<38)]
   script: 
     # force pyobjc to use conda-forge's chosen SDK
     - export CFLAGS="${CFLAGS} -isysroot ${SDKROOT:-$CONDA_BUILD_SYSROOT}"
     # force ignoring invalid compiler flag (-Wl,-export-dynamic)
-    - export CFLAGS="${CFLAGS} -Wno-unused-command-line-argument"  # [py == 37 or py == 38]
+    - export CFLAGS="${CFLAGS} -Wno-unused-command-line-argument"  # [py==37 or py==38]
     - {{ PYTHON }} -m pip install . --no-deps -vv
 
 requirements:
@@ -33,10 +33,10 @@ requirements:
     - pip
     - wheel
     - setuptools
-    - libffi
+    - libffi 3.4
   run:
     - python
-    - libffi
+    - libffi >=3.4,<3.5
 
 test:
   imports:
@@ -51,6 +51,12 @@ about:
   home: https://github.com/ronaldoussoren/pyobjc
   license: MIT
   summary: 'Python<->ObjC Interoperability Module'
+  description: |
+    The PyObjC package provides the glue needed to interface the Python interpreter
+    with the Objective-C language. At its core is the `objc` module makes
+    Objective-C objects and classes available as first-class Python citizens. It is
+    not only possible to use Objective-C objects but you can also subclass
+    Objective-C classes.
   license_family: MIT
   license_file: License.txt
   dev_url: https://github.com/ronaldoussoren/pyobjc/tree/master/pyobjc-core

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,7 +20,7 @@ build:
   skip: true  # [not osx or py<37 or (arm64 and py<38)]
   script: 
     # force pyobjc to use conda-forge's chosen SDK
-    #- export CFLAGS="${CFLAGS} -isysroot ${SDKROOT:-$CONDA_BUILD_SYSROOT}"
+    - export CFLAGS="${CFLAGS} -isysroot ${SDKROOT:-$CONDA_BUILD_SYSROOT}"
     # force ignoring invalid compiler flag (-Wl,-export-dynamic)
     - export CFLAGS="${CFLAGS} -Wno-unused-command-line-argument"  # [py==37 or py==38]
     - {{ PYTHON }} -m pip install . --no-deps -vv


### PR DESCRIPTION
**Jira ticket:** [PKG-816](https://anaconda.atlassian.net/browse/PKG-816) (pyobjc-core 9.0)

**The upstream data:**
The upstream:  https://github.com/ronaldoussoren/pyobjc/tree/v9.0/pyobjc-core
License: https://github.com/ronaldoussoren/pyobjc/blob/v9.0/pyobjc-core/License.txt
Requirements:
- https://github.com/ronaldoussoren/pyobjc/blob/v9.0/pyobjc-core/setup.cfg
- https://github.com/ronaldoussoren/pyobjc/blob/v9.0/pyobjc-core/setup.py

**_Actions:_**

1. Update a patch
2. Skip `py<37`
3. Add `libffi 3.4` pinning to `host` and update pinning in `run`
4. Add a `description` 

**Package's statistics**
<details>

 * Priority D | effort: easy | Category: other | subcategory: dependency | pkg_type: python
 * Outdated platfroms: 'osx-64', 'osx-arm64'
 * Latest version: 9.0
 * Release on PyPi:
    * version: 9.0
    * date: 2022-11-05T19:17:53
* [PyPi history](https://pypi.org/project/pyobjc-core/#history)
 * Popularity: 
    * 3 months downloads: 33973.0
    * All time:  109948 downloads -  pyobjc-core  9.0  Python<->ObjC Interoperability Module  

</details>

**Other checks:**

<details>

5. - [x] https://github.com/ronaldoussoren/pyobjc is present
6. - [x] Check the pinnings
7. - [x] `dev_url` is present
    https://github.com/ronaldoussoren/pyobjc/tree/master/pyobjc-core
8. - [x] `doc_url` is present
    https://github.com/ronaldoussoren/pyobjc/blob/master/pyobjc-core/README.txt
9. - [x] Verify that the `build_number` is correct
10. - [x] has `setuptools`
11. - [x] has `wheel`
12. - [x] `pip` in test
13. - [x] Verify the test section
14. - [x] Verify if the package is `architecture specific`
15. - [x] Verify that private modules are not mentioned in the recipe For example: (_private_module)
16.  - [x] license_file: License.txt is present
17. - [x] License: MIT
    - [x] License is `spdx` compliant
 * Check if the license identifier has correct name from the SPDX License List

| Identifier         |
|:-------------------|
| MIT                |
| MIT-0              |
| MIT-advertising    |
| MIT-CMU            |
| MIT-enna           |
| MIT-feh            |
| MIT-Modern-Variant |
| MIT-open-group     |
| MITNFA             |

18. - [x] license_family MIT is present
</details>



**Links:**
* [Anaconda Recipes feedstock](https://github.com/AnacondaRecipes/pyobjc-core-feedstock)
* [Update branch](https://github.com/AnacondaRecipes/pyobjc-core-feedstock/tree/9.0)
* [conda-forge recipe](https://github.com/{upstream}/{feedstock_name}-feedstock)
* [PyPI](https://pypi.org/project/pyobjc-core)
* [Diff between upstream and feature branch](https://github.com/conda-forge/pyobjc-core-feedstock/compare/main...AnacondaRecipes:9.0)
* [Diff between origin and feature branch](https://github.com/AnacondaRecipes/pyobjc-core-feedstock/compare/master...AnacondaRecipes:9.0)
* [The last merged PRs](https://github.com/AnacondaRecipes/pyobjc-core-feedstock/pulls?q=is%3Apr+is%3Amerged+sort%3Aupdated-desc+)

**Updating the recipe:**
If the recipe needs additional modification the update branch can be modified. Note that the PR diffs are not updated with these changes.
```
git clone -b 9.0 git@github.com:AnacondaRecipes/pyobjc-core-feedstock.git
```
