### PR TITLE
PKG-1277: Update MacOSX SDK to v10.15

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,2 @@
-channels:
-   c3i_test2: pyobjc_dev_sdk10.15
+# channels:
+#    c3i_test2: pyobjc_dev_sdk10.15

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,2 @@
-#channels:
-#    c3i_test2: pyobjc_dev
+channels:
+   c3i_test2: pyobjc_dev_sdk10.15

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -2,6 +2,6 @@ MACOSX_SDK_VERSION:       # [osx]
   - "11.3"                  # [osx and arm64]
   # SDK >=10.14 is needed on osx64 to prevent using the flag -Wno-unused-parameter, 
   # see https://github.com/ronaldoussoren/pyobjc/blob/595adfb6a08b41da8d565bb28aa508b22c946e46/pyobjc-core/setup.py#L607
-  - "10.14"                  # [osx and x86_64]
+  - "10.15"                  # [osx and x86_64]
 CONDA_BUILD_SYSROOT:       # [osx and x86_64]
-  - /opt/MacOSX10.14.sdk   # [osx and x86_64]
+  - /opt/MacOSX10.15.sdk   # [osx and x86_64]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ source:
     - fix_for_conda_build.diff
 
 build:
-  number: 0
+  number: 1
   skip: true  # [not osx or py<37 or (arm64 and py<38)]
   script: 
     # force pyobjc to use conda-forge's chosen SDK


### PR DESCRIPTION
Building with MacOSX SDK v10.15 to resolve segfaults when building the "framework" packages (they depend on `pyobjc-core`). Tested building `pyobjc-framework-cocoa` with this change and it now finishes successfully:

<img width="1728" alt="Screen Shot 2023-03-05 at 11 17 38 AM" src="https://user-images.githubusercontent.com/9688260/222972771-7e5a396d-a992-42fa-a3e0-fa4aa0c41cc6.png">

